### PR TITLE
fix: add Windows runner support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,4 +44,4 @@ runs:
   using: composite
   steps:
     - shell: bash
-      run: python ${{ github.action_path }}/entrypoint.py ${{ inputs.generator }} ${{ inputs.docker-repository }} ${{ inputs.docker-image }} ${{ inputs.generator-tag }} ${{ inputs.openapi-file }} ${{ inputs.openapi-url }} ${{ inputs.config-file }} ${{ inputs.template-dir }} ${{ inputs.command-args}}
+      run: python "${{ github.action_path }}/entrypoint.py" "$GITHUB_WORKSPACE" ${{ inputs.generator }} ${{ inputs.docker-repository }} ${{ inputs.docker-image }} ${{ inputs.generator-tag }} ${{ inputs.openapi-file }} ${{ inputs.openapi-url }} ${{ inputs.config-file }} ${{ inputs.template-dir }} ${{ inputs.command-args}}

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,10 +1,17 @@
 from subprocess import call
 from sys import argv
-from os import getenv, getuid
+import platform
 
-(_, generator, docker_repository, docker_image, generator_tag, openapi_file, openapi_url, config_file, template_dir, *args) = argv
+(_, workspace, generator, docker_repository, docker_image, generator_tag, openapi_file, openapi_url, config_file, template_dir, *args) = argv
 
-cmd = f"docker run -u {getuid()}:1001 --rm --workdir /github/workspace -v {getenv('GITHUB_WORKSPACE')}:/github/workspace"
+is_windows = platform.system() == "Windows"
+
+user_flag = ""
+if not is_windows:
+    from os import getuid
+    user_flag = f"-u {getuid()}:1001 "
+
+cmd = f"docker run {user_flag}--rm --workdir /github/workspace -v {workspace}:/github/workspace"
 cmd = f"{cmd} {docker_repository}/{docker_image}:{generator_tag} generate"
 cmd = f"{cmd} -g {generator} -o /github/workspace/{generator}-client"
 


### PR DESCRIPTION
## Problem

This action fails on `windows-latest` (and other Windows) GitHub Actions runners, since the github.action_path variable unwraps into non-bash friendly stuff (contains backslashes).
